### PR TITLE
Retirado trycatch para ter informações ao tentar enviar dados para IUGU

### DIFF
--- a/src/Iugu/Iugu.php
+++ b/src/Iugu/Iugu.php
@@ -206,28 +206,21 @@ class Iugu
      * @param array $data
      * @return StandardResponse|boolean
      */
-    private function send($method, $url, $data=array()){
-        
-        try {
-            
-            $data['headers']['Authorization'] 	= 'Basic '.$this->generateAuthorizationCode();
-            
-            $clientParams 						= array();
-            $clientParams['base_uri'] 			= $this->baseUri;
-            $clientParams['exceptions'] 		= false;
-            
-            if ($this->logsName){
-	            $clientParams['handler'] 		= $this->createLoggingHandlerStack(['{method} {uri} HTTP/{version} {req_body}', 'Resposta: {code} - {res_body}']);
-            }
-            
-            $client = new Client($clientParams);
-            
-            return $this->generateStandardResponse($client->request($method, $url, $data));
-            
-        } catch (\Exception $e) {
-            return false;
+    private function send($method, $url, $data=array())
+    {
+        $data['headers']['Authorization'] 	= 'Basic '.$this->generateAuthorizationCode();
+
+        $clientParams 						= array();
+        $clientParams['base_uri'] 			= $this->baseUri;
+        $clientParams['exceptions'] 		= false;
+
+        if ($this->logsName){
+            $clientParams['handler'] 		= $this->createLoggingHandlerStack(['{method} {uri} HTTP/{version} {req_body}', 'Resposta: {code} - {res_body}']);
         }
-        
+
+        $client = new Client($clientParams);
+
+        return $this->generateStandardResponse($client->request($method, $url, $data));
     }
     
     /**


### PR DESCRIPTION
- Estamos tratando a exception e retornando falso quando tentamos bater na iugu, fazendo com que assim o retorno da iugu que pode ser um erro não vá para o sentry e com isso perdemos informações do porque não foi criado um cliente ou uma transação dentro da IUGU, vamos ter o erro de que algo não foi criado na IUGU mas não conseguimos saber o porque de não ter sido criado pois não temos o response da iugu e nem o exception dando o erro com as informações.
- Foi validado na chamada dos endpoints que chamam a função send e todos eles já tratam o erro no idcommerce, todas as chamadas tem um try catch tratando e enviando o erro para o sentry o problema é que já é tratado antes pela biblioteca e nunca chega no sentry, o erro original. CLI-11468